### PR TITLE
Automatically purge overdue claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ For simplicity, we include a `docker-compose.yml` file, so the initial setup to 
    There is an example file included in this repository called `.env.example`.
 2. Run `docker-compose up -d`-command to start the application.
 
+Environment Variables
+=====================
+
+- `CLAIMS_MAX_AGE` - Defines the timespan (in minutes), that a claim is active. After that period, it will be released
+  again, so that anyone else can claim it. Default is 2 hours.
+
 Interacting with the API
 ========================
 

--- a/app/Console/Commands/PurgeClaims.php
+++ b/app/Console/Commands/PurgeClaims.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Claim;
+use App\Services\ClaimManager;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class PurgeClaims extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'claims:purge';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove any claims on episodes, that have passed their EOL';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param Claim $claimRepository
+     * @param ClaimManager $claimManager
+     *
+     * @return int
+     */
+    public function handle(Claim $claimRepository, ClaimManager $claimManager)
+    {
+        // load claims, that are overdue
+        $claims = $claimRepository->newModelQuery()
+            ->where('claimed_at', '<', Carbon::now()->subSeconds(config('app.claim_max_age')))
+            ->get();
+
+        // notify user how many claims are purged
+        if ($this->output->isVerbose())
+            $this->output->writeln('<comment>Purging ' . $claims->count() . ' Claims</comment>');
+
+        // purge all overdue claims
+        $claims->each(fn(Claim $claim) => $claimManager->forceDrop($claim->episode));
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/PurgeClaimsCommand.php
+++ b/app/Console/Commands/PurgeClaimsCommand.php
@@ -7,7 +7,7 @@ use App\Services\ClaimManager;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 
-class PurgeClaims extends Command
+class PurgeClaimsCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\ClaimPurgerJob;
 use App\Jobs\PodcastEpisodesImporterJob;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -25,6 +26,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
+         $schedule->job(new ClaimPurgerJob())->everyMinute();
          $schedule->job(new PodcastEpisodesImporterJob())->hourly();
     }
 

--- a/app/Events/EpisodeClaimDropped.php
+++ b/app/Events/EpisodeClaimDropped.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Episode;
+use App\Models\User;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Event to notify the system, that an episode's claim was dropped.
+ *
+ * @property Episode $episode The episode, that was claimed until now
+ * @property User|null $user The user (if available), who had claimed the episode until now
+ *
+ * @author Vincent Neubauer <v.neubauer@darlor.de>
+ * @package App\Events
+ */
+class EpisodeClaimDropped
+{
+    use SerializesModels;
+
+    public Episode $episode;
+    public ?User $user;
+
+    /**
+     * EpisodeClaimDropped constructor.
+     *
+     * @param Episode $episode
+     * @param User $user
+     */
+    public function __construct(Episode $episode, User $user)
+    {
+        $this->episode = $episode;
+        $this->user = $user;
+    }
+
+}

--- a/app/Events/EpisodeClaimed.php
+++ b/app/Events/EpisodeClaimed.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Episode;
+use App\Models\User;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Event to notify the system, that an episode was claimed.
+ *
+ * @property Episode $episode The episode, that got claimed
+ * @property User|null $user The user, who claimed the episode
+ *
+ * @author Vincent Neubauer <v.neubauer@darlor.de>
+ * @package App\Events
+ */
+class EpisodeClaimed
+{
+    use SerializesModels;
+
+    public Episode $episode;
+    public User $user;
+
+    /**
+     * EpisodeClaimDropped constructor.
+     *
+     * @param Episode $episode
+     * @param User $user
+     */
+    public function __construct(Episode $episode, User $user)
+    {
+        $this->episode = $episode;
+        $this->user = $user;
+    }
+
+}

--- a/app/Jobs/ClaimPurgerJob.php
+++ b/app/Jobs/ClaimPurgerJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Claim;
+use App\Services\ClaimManager;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ClaimPurgerJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param Claim $claimRepository
+     * @param ClaimManager $claimManager
+     *
+     * @return void
+     */
+    public function handle(Claim $claimRepository, ClaimManager $claimManager)
+    {
+        $claimRepository->newModelQuery()
+            ->where('claimed_at', '<', Carbon::now()->subSeconds(config('app.claim_max_age')))
+            ->get()
+            ->each(fn(Claim $claim) => $claimManager->forceDrop($claim->episode));
+    }
+}

--- a/app/Services/ClaimManager.php
+++ b/app/Services/ClaimManager.php
@@ -2,6 +2,9 @@
 
 namespace App\Services;
 
+use App\Events\EpisodeClaimDropped;
+use App\Events\EpisodeClaimed;
+use App\Models\Claim;
 use App\Models\Episode;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -71,6 +74,8 @@ class ClaimManager
         $episode->claimed = $user;
         $episode->save();
 
+        event(new EpisodeClaimed($episode, $user));
+
         return $episode;
     }
 
@@ -106,8 +111,13 @@ class ClaimManager
      */
     public function forceDrop(Episode $episode): Episode
     {
+        $claim = $episode->claimed;
+        $user = $claim instanceof Claim ? $claim->user : null;
+
         $episode->claimed = null;
         $episode->save();
+
+        event(new EpisodeClaimDropped($episode, $user));
 
         return $episode;
     }

--- a/app/Services/ClaimManager.php
+++ b/app/Services/ClaimManager.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Episode;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+class ClaimManager
+{
+    use AuthorizesRequests;
+
+    /**
+     * Checks if an episode is already claimed by any user.
+     *
+     * @param Episode $episode
+     *
+     * @return bool
+     */
+    public function isClaimed(Episode $episode): bool
+    {
+        return $episode->claimed instanceof User;
+    }
+
+    /**
+     * Checks if an episode is already claimed by any user.
+     *
+     * @param Episode $episode
+     *
+     * @return bool
+     */
+    public function isClaimedBy(Episode $episode, User $user): bool
+    {
+        return $this->isClaimed($episode) && $episode->claimed->getKey() === $user->getKey();
+    }
+
+    /**
+     * Attempts to claim an episode. This will fail if user isn't authorized to do that, or if the episode is already
+     * claimed.
+     *
+     * @param Episode $episode
+     * @param User $user
+     *
+     * @return Episode
+     * @throws AuthorizationException Either episode is already claimed or the claim policy prevents this action.
+     */
+    public function claim(Episode $episode, User $user): Episode
+    {
+        if ($this->isClaimed($episode) && !$this->isClaimedBy($episode, $user)) {
+            throw new AuthorizationException('Episode is claimed by someone else');
+        }
+
+        if ($this->authorizeForUser($user, 'claim', $episode)) {
+            throw new AuthorizationException('Episode cannot be claimed');
+        }
+
+        return $this->forceClaim($episode, $user);
+    }
+
+    /**
+     * Claims an episode by the given user. This will overwrite any existing claims! This will also ignore any policies.
+     *
+     * @param Episode $episode
+     * @param User $user
+     *
+     * @return Episode The claimed episode
+     */
+    public function forceClaim(Episode $episode, User $user): Episode
+    {
+        $episode->claimed = $user;
+        $episode->save();
+
+        return $episode;
+    }
+
+    /**
+     * Attempt to remove the claim from the given episode. This will fail if the claim was done by another user or if
+     * the user isn't authorized to do that.
+     *
+     * @param Episode $episode
+     * @param User $user
+     *
+     * @return Episode
+     * @throws AuthorizationException Either episode is claimed by someone else or a policy prevents this action.
+     */
+    public function drop(Episode $episode, User $user)
+    {
+        if ($this->isClaimed($episode) && !$this->isClaimedBy($episode, $user)) {
+            throw new AuthorizationException('Episode is claimed by someone else');
+        }
+
+        if ($this->authorizeForUser($user, 'unclaim', $episode)) {
+            throw new AuthorizationException('Claim cannot be dropped');
+        }
+
+        return $this->forceDrop($episode);
+    }
+
+    /**
+     * Removes any claim from the episode. This will ignore any policies or who owns the claim and just remove it!
+     *
+     * @param Episode $episode
+     *
+     * @return Episode The claim-free episode
+     */
+    public function forceDrop(Episode $episode): Episode
+    {
+        $episode->claimed = null;
+        $episode->save();
+
+        return $episode;
+    }
+}

--- a/app/Services/ClaimManager.php
+++ b/app/Services/ClaimManager.php
@@ -71,11 +71,14 @@ class ClaimManager
      */
     public function forceClaim(Episode $episode, User $user): Episode
     {
-        $episode->claimed = $user;
-        $episode->save();
+        $claim = new Claim();
+        $claim->claimed_at = now();
+        $claim->user()->associate($user);
+
+        $episode->claimed()->save($claim);
+        $episode->refresh();
 
         event(new EpisodeClaimed($episode, $user));
-
         return $episode;
     }
 
@@ -114,8 +117,8 @@ class ClaimManager
         $claim = $episode->claimed;
         $user = $claim instanceof Claim ? $claim->user : null;
 
-        $episode->claimed = null;
-        $episode->save();
+        $episode->claimed()->delete();
+        $episode->refresh();
 
         event(new EpisodeClaimDropped($episode, $user));
 

--- a/config/app.php
+++ b/config/app.php
@@ -231,4 +231,16 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Claims Max Age
+    |--------------------------------------------------------------------------
+    |
+    | This determines the timespan, for which a claim is valid. After that
+    | period passed, it will be released again for anyone else to claim.
+    |
+    */
+
+    'claims_max_age' => env('CLAIMS_MAX_AGE', 120) * 60,
+
 ];


### PR DESCRIPTION
This PR adds a job, that purges overdue claims each minute, if the queue worker runs.
This provides a command, to purge them manually, too.

Additionally, this adds a claim manager service to unify the behavior of claiming and releasing episodes, while also firing events for these actions.

The TTL of claims can be configured through the `.env` file and will fall back to two hours.